### PR TITLE
Engine Linting Issues and Naming Fix

### DIFF
--- a/src/scarr/engines/NICV.py
+++ b/src/scarr/engines/NICV.py
@@ -38,12 +38,7 @@ class NICV(Engine):
         noises = np.sum(self.sum_sq, axis=0) / np.sum(self.trace_counts) - (mean)**2
 
         
-        self.results = signals / noises
-        
-    def _get_result(self):
-        if self.results is None:
-            self.calculate()
-        return self.results
+        return signals / noises
     
     @staticmethod
     @nb.njit(parallel=True, fastmath=True)  

--- a/src/scarr/engines/NICV.py
+++ b/src/scarr/engines/NICV.py
@@ -39,7 +39,7 @@ class NICV(Engine):
         noises = np.sum(self.sum_sq, axis=0) / np.sum(self.trace_counts) - (mean)**2
 
         return signals / noises
-    
+
     @staticmethod
     @nb.njit(parallel=True, fastmath=True)
     def internal_state_update(traces: np.ndarray, plaintext: np.ndarray, counts, sums, sums_sq):

--- a/src/scarr/engines/NICV.py
+++ b/src/scarr/engines/NICV.py
@@ -9,6 +9,7 @@ import numpy as np
 import numba as nb
 from .engine import Engine
 
+
 class NICV(Engine):
 
     def __init__(self) -> None:
@@ -17,7 +18,7 @@ class NICV(Engine):
         self.means = None
         self.moments = None
         self.results = None
-    
+
     def update(self, traces: np.ndarray, plaintext: np.ndarray):
         self.internal_state_update(traces, plaintext, self.trace_counts, self.sum, self.sum_sq)
 
@@ -31,32 +32,28 @@ class NICV(Engine):
         self.trace_counts = self.trace_counts[self.trace_counts != 0]
 
         mean = np.sum(self.sum, axis=0) / np.sum(self.trace_counts)
-        signals = (((self.sum / self.trace_counts[:,None]) - mean))**2
-        signals *= (self.trace_counts / self.trace_counts.shape[0])[:,None]
+        signals = (((self.sum / self.trace_counts[:, None]) - mean))**2
+        signals *= (self.trace_counts / self.trace_counts.shape[0])[:, None]
         signals = np.sum(signals, axis=0)
 
         noises = np.sum(self.sum_sq, axis=0) / np.sum(self.trace_counts) - (mean)**2
 
-        
         return signals / noises
     
     @staticmethod
-    @nb.njit(parallel=True, fastmath=True)  
+    @nb.njit(parallel=True, fastmath=True)
     def internal_state_update(traces: np.ndarray, plaintext: np.ndarray, counts, sums, sums_sq):
         for sample in nb.prange(traces.shape[1]):
             for trace in range(traces.shape[0]):
                 if sample == 0:
                     counts[plaintext[trace]] += 1
                 sums[plaintext[trace], sample] += traces[trace, sample]
-                sums_sq[plaintext[trace], sample] += np.square(traces[trace, sample])   
+                sums_sq[plaintext[trace], sample] += np.square(traces[trace, sample])
 
     def populate(self, sample_length):
-        try:
-            # Count for each plaintext value
-            self.trace_counts = np.zeros((256), dtype=np.uint16)
-            # Mean value for each hex value and each sample point
-            self.sum = np.zeros((256, sample_length), dtype=np.float32)
-            # Moment value for each hex value and each sample point
-            self.sum_sq = np.zeros((256, sample_length), dtype=np.float32)
-        except:
-            print("Error populating.")
+        # Count for each plaintext value
+        self.trace_counts = np.zeros((256), dtype=np.uint16)
+        # Mean value for each hex value and each sample point
+        self.sum = np.zeros((256, sample_length), dtype=np.float32)
+        # Moment value for each hex value and each sample point
+        self.sum_sq = np.zeros((256, sample_length), dtype=np.float32)

--- a/src/scarr/engines/cpa.py
+++ b/src/scarr/engines/cpa.py
@@ -46,13 +46,13 @@ class CPA(Engine):
 
             for tile_x, tile_y, results, candidates in starmap_results:
                 if self.final_results is None:
-                    self.final_results = np.zeros((len(container.tiles), 
-                                                   len(container.bytes), 
-                                                   results.shape[1], 
-                                                   256, 
+                    self.final_results = np.zeros((len(container.tiles),
+                                                   len(container.bytes),
+                                                   results.shape[1],
+                                                   256,
                                                    container.sample_length), dtype=np.float64)
-                    self.final_candidates = np.zeros((len(container.tiles), 
-                                                      len(container.bytes), 
+                    self.final_candidates = np.zeros((len(container.tiles),
+                                                      len(container.bytes),
                                                       results.shape[1]), dtype=np.uint8)
 
                 tile_index = container.tiles.index((tile_x, tile_y))
@@ -160,7 +160,7 @@ class CPA(Engine):
         to_sqrt[to_sqrt < 0] = 0
         denom_model = np.sqrt(to_sqrt)
 
-        denominator = denom_model[:,:,None]*denom_sample
+        denominator = denom_model[:, :, None]*denom_sample
 
         denominator[denominator == 0] = 1
 
@@ -168,7 +168,7 @@ class CPA(Engine):
 
     def get_candidate(self):
         return self.final_candidates
-    
+
     def populate(self, sample_length, num_bytes):
         # Sum of the model so far
         self.model_sum = np.zeros((256, num_bytes), dtype=np.float32)
@@ -181,7 +181,6 @@ class CPA(Engine):
         # Sum of the product of the samples and the models
         self.prod_sum = np.zeros((256 * num_bytes, sample_length), dtype=np.float32)
 
-    
     def update(self, traces: np.ndarray, data: np.ndarray):
         # Update the number of rows processed
         self.trace_count += traces.shape[0]

--- a/src/scarr/engines/cpa.py
+++ b/src/scarr/engines/cpa.py
@@ -10,9 +10,10 @@ from .engine import Engine
 from multiprocessing.pool import Pool
 import asyncio
 
+
 class CPA(Engine):
 
-    def __init__(self, model, convergence_step = None) -> None:
+    def __init__(self, model, convergence_step=None) -> None:
         self.model = model
 
         self.trace_count = 0
@@ -42,11 +43,17 @@ class CPA(Engine):
             starmap_results = pool.starmap(self.run_workload, workload)
             pool.close()
             pool.join()
-            
+
             for tile_x, tile_y, results, candidates in starmap_results:
                 if self.final_results is None:
-                    self.final_results = np.zeros((len(container.tiles), len(container.bytes), results.shape[1], 256, container.sample_length), dtype=np.float64)
-                    self.final_candidates = np.zeros((len(container.tiles), len(container.bytes), results.shape[1]), dtype=np.uint8)
+                    self.final_results = np.zeros((len(container.tiles), 
+                                                   len(container.bytes), 
+                                                   results.shape[1], 
+                                                   256, 
+                                                   container.sample_length), dtype=np.float64)
+                    self.final_candidates = np.zeros((len(container.tiles), 
+                                                      len(container.bytes), 
+                                                      results.shape[1]), dtype=np.uint8)
 
                 tile_index = container.tiles.index((tile_x, tile_y))
                 self.final_results[tile_index] = results
@@ -71,8 +78,8 @@ class CPA(Engine):
             for batch in container.get_batches(tile_x, tile_y):
                 if traces_processed >= self.convergence_step:
                     result = self.calculate()
-                    self.results[:,converge_index,:,:] = result
-                    self.candidates[:,converge_index] = self.find_candidate(result)
+                    self.results[:, converge_index, :, :] = result
+                    self.candidates[:, converge_index] = self.find_candidate(result)
                     traces_processed = 0
                     converge_index += 1
 
@@ -84,11 +91,11 @@ class CPA(Engine):
                 traces_processed += traces.shape[0]
 
             result = self.calculate()
-            self.results[:,converge_index,:,:] = result
-            self.candidates[:,converge_index] = self.find_candidate(result)
+            self.results[:, converge_index, :, :] = result
+            self.candidates[:, converge_index] = self.find_candidate(result)
 
         return tile_x, tile_y, self.results, self.candidates
-    
+
     async def batch_loop(self, container):
         index = 0
         batch = container.get_batch_index(index)
@@ -99,11 +106,11 @@ class CPA(Engine):
 
         while len(batch) > 0:
             if traces_processed >= self.convergence_step:
-                    result = self.calculate()
-                    self.results[:,converge_index,:,:] = result
-                    self.candidates[:,converge_index] = self.find_candidate(result)
-                    traces_processed = 0
-                    converge_index += 1
+                result = self.calculate()
+                self.results[:, converge_index, :, :] = result
+                self.candidates[:, converge_index] = self.find_candidate(result)
+                traces_processed = 0
+                converge_index += 1
 
             # Generate modeled power values for plaintext values
             model = np.apply_along_axis(self.model.calculate_table, axis=1, arr=batch[0])
@@ -117,8 +124,8 @@ class CPA(Engine):
             await task
 
         result = self.calculate()
-        self.results[:,converge_index,:,:] = result
-        self.candidates[:,converge_index] = self.find_candidate(result)
+        self.results[:, converge_index, :, :] = result
+        self.candidates[:, converge_index] = self.find_candidate(result)
 
     async def async_update(self, traces: np.ndarray, data: np.ndarray):
         # Update the number of rows processed
@@ -135,7 +142,6 @@ class CPA(Engine):
         # Update product accumulator
         self.prod_sum += np.matmul(data.T, traces)
 
-
     def calculate(self):
         # Sample mean computation
         sample_mean = np.divide(self.sample_sum, self.trace_count)
@@ -144,7 +150,7 @@ class CPA(Engine):
 
         prod_mean = np.divide(self.prod_sum.reshape(256, self.model_sum.shape[1], self.sample_sum.shape[0]), self.trace_count)
         # Calculate correlation coefficient numerator
-        numerator = np.subtract(prod_mean, model_mean[:,:,None]*sample_mean)
+        numerator = np.subtract(prod_mean, model_mean[:, :, None]*sample_mean)
         # Calculate correlation coeefficient denominator sample part
         to_sqrt = np.subtract(np.divide(self.sample_sq_sum, self.trace_count), np.square(sample_mean))
         to_sqrt[to_sqrt < 0] = 0
@@ -165,18 +171,18 @@ class CPA(Engine):
     
     def populate(self, sample_length, num_bytes):
         # Sum of the model so far
-        self.model_sum = np.zeros((256, num_bytes),dtype=np.float32)
+        self.model_sum = np.zeros((256, num_bytes), dtype=np.float32)
         # Sum of the model squared so far
-        self.model_sq_sum = np.zeros((256, num_bytes),dtype=np.float32)
+        self.model_sq_sum = np.zeros((256, num_bytes), dtype=np.float32)
         # Sum of the samples observed
-        self.sample_sum = np.zeros((sample_length),dtype=np.float32)
+        self.sample_sum = np.zeros((sample_length), dtype=np.float32)
         # Sum of the samples observed squared
-        self.sample_sq_sum = np.zeros((sample_length),dtype=np.float32)
+        self.sample_sq_sum = np.zeros((sample_length), dtype=np.float32)
         # Sum of the product of the samples and the models
-        self.prod_sum = np.zeros((256 * num_bytes, sample_length),dtype=np.float32)
+        self.prod_sum = np.zeros((256 * num_bytes, sample_length), dtype=np.float32)
 
-    # Update the values using the current batch of trace samples and the computed model incrementing the vals into the accumulators
-    def update(self, traces:np.ndarray, data:np.ndarray):
+    
+    def update(self, traces: np.ndarray, data: np.ndarray):
         # Update the number of rows processed
         self.trace_count += traces.shape[0]
         # Update sample accumulator
@@ -195,6 +201,6 @@ class CPA(Engine):
         candidate = [None for _ in range(result.shape[0])]
 
         for i in range(result.shape[0]):
-            candidate[i] = np.unravel_index(np.abs(result[i,:,:]).argmax(), result[i,:,:].shape[0:])[0]
+            candidate[i] = np.unravel_index(np.abs(result[i, :, :]).argmax(), result[i, :, :].shape[0:])[0]
 
         return candidate

--- a/src/scarr/engines/cpa.py
+++ b/src/scarr/engines/cpa.py
@@ -164,7 +164,7 @@ class CPA(Engine):
 
         denominator[denominator == 0] = 1
 
-        return np.divide(numerator, denominator).swapaxes(0,1)
+        return np.divide(numerator, denominator).swapaxes(0, 1)
 
     def get_candidate(self):
         return self.final_candidates

--- a/src/scarr/engines/engine.py
+++ b/src/scarr/engines/engine.py
@@ -10,6 +10,7 @@ from multiprocessing.pool import Pool
 import os
 import asyncio
 
+
 class Engine:
     """
     Base class that engines inherit from.
@@ -19,14 +20,14 @@ class Engine:
 
     def run(self, container):
         final_results = np.zeros((len(container.tiles), len(container.bytes), container.sample_length), dtype=np.float32)
-        #with Pool(processes=int(os.cpu_count()/2),maxtasksperchild=1000) as pool: #used for benchmarking
+        # with Pool(processes=int(os.cpu_count()/2),maxtasksperchild=1000) as pool: #used for benchmarking
         with Pool(processes=int(os.cpu_count()/2)) as pool:
             workload = []
             for tile in container.tiles:
                 (tile_x, tile_y) = tile
                 for byte in container.bytes:
                     workload.append((self, container, tile_x, tile_y, byte))
-            starmap_results = pool.starmap(self.run_workload, workload, chunksize=1) #possibly more testing needed
+            starmap_results = pool.starmap(self.run_workload, workload, chunksize=1)  # Possibly more testing needed
             pool.close()
             pool.join()
 
@@ -48,7 +49,7 @@ class Engine:
                 self.update(batch[-1], np.squeeze(batch[0]))
 
         return tile_x, tile_y, byte, self.calculate()
-    
+
     async def batch_loop(self, container):
         index = 0
         batch = container.get_batch_index(index)
@@ -64,7 +65,7 @@ class Engine:
         """
         Function that updates the statistics of the algorithm to be called by the container class.
         Gets passed in an array of traces and an array of plaintext from the trace_handler class.
-        Returns None. 
+        Returns None.
         """
         pass
 
@@ -72,7 +73,7 @@ class Engine:
         """
         Function that updates the statistics of the algorithm to be called by the container class.
         Gets passed in an array of traces and an array of plaintext from the trace_handler class.
-        Returns None. 
+        Returns None.
         """
         pass
 

--- a/src/scarr/engines/engine.py
+++ b/src/scarr/engines/engine.py
@@ -26,19 +26,19 @@ class Engine:
                 (tile_x, tile_y) = tile
                 for byte in container.bytes:
                     workload.append((self, container, tile_x, tile_y, byte))
-            starmap_results = pool.starmap(self._run, workload, chunksize=1) #possibly more testing needed
+            starmap_results = pool.starmap(self.run_workload, workload, chunksize=1) #possibly more testing needed
             pool.close()
             pool.join()
 
-            for tile_x, tile_y, byte_pos, _result in starmap_results:
+            for tile_x, tile_y, byte_pos, tmp_result in starmap_results:
                 tile_index = list(container.tiles).index((tile_x, tile_y))
                 byte_index = list(container.bytes).index(byte_pos)
-                final_results[tile_index, byte_index] = _result
+                final_results[tile_index, byte_index] = tmp_result
 
             self.final_results = final_results
 
     @staticmethod
-    def _run(self, container, tile_x, tile_y, byte):
+    def run_workload(self, container, tile_x, tile_y, byte):
         self.populate(container.sample_length)
         container.configure(tile_x, tile_y, [byte])
         if container.fetch_async:
@@ -47,7 +47,7 @@ class Engine:
             for batch in container.get_batches(tile_x, tile_y, byte):
                 self.update(batch[-1], np.squeeze(batch[0]))
 
-        return tile_x, tile_y, byte, self._get_result()
+        return tile_x, tile_y, byte, self.calculate()
     
     async def batch_loop(self, container):
         index = 0
@@ -77,14 +77,6 @@ class Engine:
         pass
 
     def calculate(self):
-        pass
-
-    def _get_result(self):
-        """
-        Function for finalizing the calculations of an algorithm.
-        Gets passed in nothing.
-        Returns Results.
-        """
         pass
 
     def get_result(self):

--- a/src/scarr/engines/mia.py
+++ b/src/scarr/engines/mia.py
@@ -106,13 +106,13 @@ class MIA(Engine):
         trace_counts = trace_hist.sum(axis=1)
         trace_counts[trace_counts == 0] = 1
 
-        trace_pdf = (trace_hist.swapaxes(0,1) / trace_counts).swapaxes(0, 1)
+        trace_pdf = (trace_hist.swapaxes(0, 1) / trace_counts).swapaxes(0, 1)
         trace_pdf[trace_pdf == 0] = 1
 
         trace_model_counts = self.histogram.sum(axis=2)
         trace_model_counts[trace_model_counts == 0] = 1
 
-        trace_model_pdf = (self.histogram.swapaxes(0,1).swapaxes(1,2) / trace_model_counts[:,0]).swapaxes(1,2).swapaxes(0,1)
+        trace_model_pdf = (self.histogram.swapaxes(0, 1).swapaxes(1, 2) / trace_model_counts[:, 0]).swapaxes(1, 2).swapaxes(0, 1)
         trace_model_pdf[trace_model_pdf == 0] = 1
 
         model_probabilities = trace_model_counts / trace_counts
@@ -136,7 +136,7 @@ class MIA(Engine):
         converge_index = 0
         for batch in container.get_batches(tile_x, tile_y, byte):
             if traces_processed >= self.convergence_step:
-                result = self.calculate().swapaxes(0,1)
+                result = self.calculate().swapaxes(0, 1)
                 self.results[converge_index, :, :] = result
                 self.candidates[converge_index] = self.find_candidate(result)
                 traces_processed = 0
@@ -167,7 +167,7 @@ class MIA(Engine):
 
         while len(batch) > 0:
             if traces_processed >= self.convergence_step:
-                result = self.calculate().swapaxes(0,1)
+                result = self.calculate().swapaxes(0, 1)
                 self.results[converge_index, :, :] = result
                 self.candidates[converge_index] = self.find_candidate(result)
                 traces_processed = 0
@@ -179,7 +179,7 @@ class MIA(Engine):
             index += 1
             await task
 
-        result = self.calculate().swapaxes(0,1)
+        result = self.calculate().swapaxes(0, 1)
         self.results[converge_index, :, :] = result
         self.candidates[converge_index] = self.find_candidate(result)
 

--- a/src/scarr/engines/mia.py
+++ b/src/scarr/engines/mia.py
@@ -150,7 +150,7 @@ class MIA(Engine):
 
             self.update(samples, plaintext)
 
-        result = self.calculate().swapaxes(0,1)
+        result = self.calculate().swapaxes(0, 1)
         self.results[converge_index, :, :] = result
         self.candidates[converge_index] = self.find_candidate(result)
 

--- a/src/scarr/engines/mim.py
+++ b/src/scarr/engines/mim.py
@@ -117,7 +117,7 @@ class MIM(Engine):
         trace_pdf[trace_pdf == 0] = 1
 
         trace_profile_counts = self.histogram.sum(axis=4)
-        trace_profile_counts[trace_profile_counts==0] = 1
+        trace_profile_counts[trace_profile_counts == 0] = 1
 
         trace_profile_pdf = (self.histogram.swapaxes(3, 4).swapaxes(2, 3) / trace_profile_counts[:, 0]).swapaxes(2, 3).swapaxes(3, 4)
         trace_profile_pdf[trace_profile_pdf == 0] = 1

--- a/src/scarr/engines/snr.py
+++ b/src/scarr/engines/snr.py
@@ -38,12 +38,7 @@ class SNR(Engine):
         noises = np.mean(variances, axis=0)
         noises[noises == 0] = 1
         
-        self.results = signals / noises
-        
-    def _get_result(self):
-        if self.results is None:
-            self.calculate()
-        return self.results
+        return signals / noises
     
     @staticmethod
     @nb.njit(parallel=True, cache=True, nogil=True)  

--- a/src/scarr/engines/snr.py
+++ b/src/scarr/engines/snr.py
@@ -9,6 +9,7 @@ import numpy as np
 import numba as nb
 from .engine import Engine
 
+
 class SNR(Engine):
 
     def __init__(self) -> None:
@@ -17,7 +18,7 @@ class SNR(Engine):
         self.means = None
         self.moments = None
         self.results = None
-    
+
     def update(self, traces: np.ndarray, plaintext: np.ndarray):
         self.internal_state_update(traces, plaintext, self.trace_counts, self.sum, self.sum_sq)
 
@@ -30,18 +31,18 @@ class SNR(Engine):
         self.sum_sq = self.sum_sq[self.trace_counts > 0, :]
         self.trace_counts = self.trace_counts[self.trace_counts > 0]
 
-        means = self.sum / self.trace_counts[:,None]
+        means = self.sum / self.trace_counts[:, None]
         signals = np.var(means, axis=0)
 
-        variances = (self.sum_sq / self.trace_counts[:,None]) - (means**2)
+        variances = (self.sum_sq / self.trace_counts[:, None]) - (means**2)
         variances[variances < 0] = 0
         noises = np.mean(variances, axis=0)
         noises[noises == 0] = 1
-        
+
         return signals / noises
-    
+
     @staticmethod
-    @nb.njit(parallel=True, cache=True, nogil=True)  
+    @nb.njit(parallel=True, cache=True, nogil=True)
     def internal_state_update(traces: np.ndarray, plaintext: np.ndarray, counts, sums, sums_sq):
         for sample in nb.prange(traces.shape[1]):
             local_sums = np.empty(256, dtype=np.float64)
@@ -51,8 +52,8 @@ class SNR(Engine):
             local_sums_sq[:] = 0.
             local_counts[:] = 0
             for trace in range(traces.shape[0]):
-                if sample == 0: 
-                    local_counts[plaintext[trace]] += 1       
+                if sample == 0:
+                    local_counts[plaintext[trace]] += 1
                 local_sums[plaintext[trace]] += traces[trace, sample]
                 local_sums_sq[plaintext[trace]] += traces[trace, sample]**2
 
@@ -61,18 +62,17 @@ class SNR(Engine):
             counts += local_counts
 
     def populate(self, sample_length):
-        try:
-            # Count for each plaintext value
-            self.trace_counts = np.zeros((256), dtype=np.uint32)
-            # Mean value for each hex value and each sample point
-            self.sum = np.zeros((256, sample_length), dtype=np.float64)
-            # Moment value for each hex value and each sample point
-            self.sum_sq = np.zeros((256, sample_length), dtype=np.float64)
-        except:
-            print("Error populating.")
+        # Count for each plaintext value
+        self.trace_counts = np.zeros((256), dtype=np.uint32)
+        # Mean value for each hex value and each sample point
+        self.sum = np.zeros((256, sample_length), dtype=np.float64)
+        # Moment value for each hex value and each sample point
+        self.sum_sq = np.zeros((256, sample_length), dtype=np.float64)
+
 
 class SNR_Evaluator(SNR):
-     
+
+
     @staticmethod
     def _run(self, container, tile_x, tile_y, byte):
         for batch in container.get_batches_by_byte(tile_x, tile_y, byte):

--- a/src/scarr/engines/snr.py
+++ b/src/scarr/engines/snr.py
@@ -72,7 +72,6 @@ class SNR(Engine):
 
 class SNR_Evaluator(SNR):
 
-
     @staticmethod
     def _run(self, container, tile_x, tile_y, byte):
         for batch in container.get_batches_by_byte(tile_x, tile_y, byte):

--- a/src/scarr/engines/stats.py
+++ b/src/scarr/engines/stats.py
@@ -10,6 +10,7 @@ from .engine import Engine
 from multiprocessing.pool import Pool
 import asyncio
 
+
 class Stats(Engine):
     def __init__(self):
         self.means = None
@@ -38,7 +39,7 @@ class Stats(Engine):
 
             self.means = tile_means
             self.variances = tile_variances
-    
+
     @staticmethod
     def _run(self, container, tile_x, tile_y):
         self.count = np.uint32(0)
@@ -53,7 +54,7 @@ class Stats(Engine):
                 self.update(batch[-1])
 
         return tile_x, tile_y, self.mean, self.variance / self.count
-    
+
     async def stat_batch_loop(self, container):
         index = 0
         batch = container.get_batch_index(index)
@@ -67,7 +68,7 @@ class Stats(Engine):
 
     def update(self, traces: np.ndarray):
         self.count += traces.shape[0]
-        
+
         delta1 = traces - self.mean
 
         self.mean += np.sum(delta1 / self.count, axis=0)
@@ -78,7 +79,7 @@ class Stats(Engine):
 
     async def async_update(self, traces: np.ndarray):
         self.count += traces.shape[0]
-        
+
         delta1 = traces - self.mean
 
         self.mean += np.sum(delta1 / self.count, axis=0)
@@ -89,9 +90,9 @@ class Stats(Engine):
 
     def get_means(self):
         return self.means
-    
+
     def get_variances(self):
         return self.variances
-    
+
     def get_tiles(self):
         return self.tiles

--- a/src/scarr/engines/ttest.py
+++ b/src/scarr/engines/ttest.py
@@ -68,7 +68,7 @@ class Ttest(Engine):
         else:
             results[0] = np.divide(self.sums2, self.traces_len)
             results[1] = np.subtract(np.divide(self.sums_sq2, self.traces_len), (results[0]**2))
-        
+
         return results
 
     def run(self, container):
@@ -78,7 +78,7 @@ class Ttest(Engine):
         self.batch_size = container.data.batch_size
         interm_results = np.empty((len(container.tiles), 2, 2, container.min_samples_length), dtype=np.float32)
         final_results = np.zeros((len(container.tiles), container.min_samples_length), dtype=np.float32)
-        trace_counts = [0,1]
+        trace_counts = [0, 1]
         # Begin multiprocess pool of tasks
         pool = Pool()
         workload = []


### PR DESCRIPTION
- Removed all instances of _get_result()
- Changed all instances of _run to run_workload
- Changed all instances of _get_candidate to find_candidate
- Changed _result in the Engine to tmp_result
- Removed internal_state_update from CPA
- Fixed all flake8 linting issues with the following files : cpa.py, NICV.py, engine.py, mia.py, mim.py, snr.py, stats.py, ttest.py.