### PR TITLE
Update pyproject.toml to fix dependency errors with Zarr

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ This Source Code Form is "Incompatible With Secondary Licenses", as defined by t
 SCARR was initiated and designed by Vincent Immler out of a necessity to support his teaching and research at Oregon State University. Under his guidance, two undergraduate students at Oregon State University, Jonah Bosland and Stefan Ene, developed the majority of the initial implementation during the summer 2023. Peter Baumgartner helped us with the testing and analysis on NUMA platforms.
 
 Additional contributions by (new authors, add yourself here):
-* to be added
+* Matt Ruff
 * to be added
 
 # Copyright

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,6 +13,12 @@ authors = [
 description = "A high-performance SCA library for datasets that include NxM EM trace grids."
 readme = "README.md"
 requires-python = ">=3.10"
+dependencies = [
+	'numpy',
+	'numba',
+	'zarr[jupyter]',
+	'ruff',
+]
 license = {text = "MPL-2.0"}
 classifiers = [
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Pyproject.toml previously did not install the correct dependencies for the project. It did not include Zarr's optional dependencies for Jupyter including Jupyter Notebook, ipytree, and ipywidgets. This PR fixes pyproject.toml by including the optional dependencies for Zarr. 

As this is my first contribution to the project, this PR also includes an update to the additional contributions/authors section of README.md.