### PR TITLE
Renaming of slice variables to slab - Fixes issue #21

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,7 @@ Additional contributions by (new contributors, add yourself here):
 * Alexander Merino
 * Tristan Long
 * Kayla Barton
+* Christopher McLean
 
 # Copyright
 

--- a/devtools/data_creation/correlation_data.py
+++ b/devtools/data_creation/correlation_data.py
@@ -35,11 +35,11 @@ class CorrelationData:
 
     def configure(self, tile_x, tile_y, model_positions, convergence_step=None):
         self.model_positions = model_positions
-        self.slices = []
+        self.slabs = []
         batch_start_index = 0
         while batch_start_index < self.num_traces:
             entry_count = min(self.batch_size, self.num_traces - batch_start_index)
-            self.slices.append(slice(batch_start_index, batch_start_index+entry_count))
+            self.slabs.append(slice(batch_start_index, batch_start_index+entry_count))
             batch_start_index += entry_count
         
         return 1
@@ -53,25 +53,25 @@ class CorrelationData:
     def get_key(self):
         return self.key
     
-    def get_byte_batch(self, slice, model_pos):
+    def get_byte_batch(self, slab, model_pos):
 
-        return [self.plaintext[slice, [model_pos]], self.key[[model_pos]], self.traces[slice,:]]
+        return [self.plaintext[slab, [model_pos]], self.key[[model_pos]], self.traces[slab,:]]
     
     def get_batches_by_byte(self, tile_x, tile_y, model_pos):
-        for slice in self.slices:
-            yield self.get_byte_batch(slice, model_pos)
+        for slab in self.slabs:
+            yield self.get_byte_batch(slab, model_pos)
     
-    def get_batch(self, slice):
+    def get_batch(self, slab):
 
-        return [self.plaintext[slice,self.model_positions], self.key[self.model_positions], self.traces[slice,:]]
+        return [self.plaintext[slab,self.model_positions], self.key[self.model_positions], self.traces[slab,:]]
     
     def get_batches_all(self, tile_x, tile_y):
-        for slice in self.slices:
-            yield self.get_batch(slice)
+        for slab in self.slabs:
+            yield self.get_batch(slab)
 
     def get_batch_index(self, index):
 
-        if index >= len(self.slices):
+        if index >= len(self.slabs):
             return []
         
-        return [self.plaintext[self.slices[index], self.model_positions], self.key[self.model_positions], self.traces[self.slices[index], :]]
+        return [self.plaintext[self.slabs[index], self.model_positions], self.key[self.model_positions], self.traces[self.slabs[index], :]]

--- a/license_check.ini
+++ b/license_check.ini
@@ -24,6 +24,7 @@ authorized_licenses:
         Historical Permission Notice and Disclaimer (HPND)
         Other/Proprietary
         The Unlicense (Unlicense)
+        CMU License (MIT-CMU)
 
 unauthorized_licenses:
         gpl v3

--- a/src/scarr/container/container.py
+++ b/src/scarr/container/container.py
@@ -29,7 +29,7 @@ class Container:
     - byte_positions: The byte positions to be processed by the algorithm has a default value of [0]
     - tile_positions: The tile positions that are to have the byte positions processed default value of [(0,0)]
     """
-    def __init__(self, options: ContainerOptions, Async = True, model_positions = [0], tile_positions = [(0,0)], filters = [], points=[], trace_index=[], slice=[], stride=1) -> None:
+    def __init__(self, options: ContainerOptions, Async = True, model_positions = [0], tile_positions = [(0,0)], filters = [], points=[], trace_index=[], slab=[], stride=1) -> None:
         self.engine = options.engine
         self.data = options.handler
         self.data2 = options.handler2  # second trace (only t-test)
@@ -48,28 +48,28 @@ class Container:
         self.min_traces_length = 0
 
         if len(points) > 0:
-            self.slice_index = points
-            self.time_slice = []
+            self.slab_points = points
+            self.slab_range = []
             self.stride = 1
             self.sample_length = len(points)
-        elif len(slice) == 2 and stride > 1:
-            self.slice_index = []
-            self.time_slice = slice
+        elif len(slab) == 2 and stride > 1:
+            self.slab_points = []
+            self.slab_range = slab
             self.stride = stride
-            self.sample_length = math.ceil((self.time_slice[1] - self.time_slice[0]) / stride)
-        elif len(slice) == 2:
-            self.slice_index = []
-            self.time_slice = slice
+            self.sample_length = math.ceil((self.slab_range[1] - self.slab_range[0]) / stride)
+        elif len(slab) == 2:
+            self.slab_points = []
+            self.slab_range = slab
             self.stride = 1
-            self.sample_length = int(self.time_slice[1] - self.time_slice[0])
+            self.sample_length = int(self.slab_range[1] - self.slab_range[0])
         elif stride > 1:
-            self.slice_index = []
-            self.time_slice = []
+            self.slab_points = []
+            self.slab_range = []
             self.stride = stride
             self.sample_length = math.ceil(self.data.sample_length / self.stride)
         else:
-            self.slice_index = []
-            self.time_slice = []
+            self.slab_points = []
+            self.slab_range = []
             self.stride = 1
             self.sample_length = self.data.sample_length
         
@@ -86,13 +86,13 @@ class Container:
         for filter in self.filters:
             filter.configure(tile_x, tile_y)
         # int() casting needed for random typing linux bug
-        return int(self.data.configure(tile_x, tile_y, model_positions, self.slice_index, self.trace_index, self.time_slice, self.stride, convergence_step))
+        return int(self.data.configure(tile_x, tile_y, model_positions, self.slab_points, self.trace_index, self.slab_range, self.stride, convergence_step))
 
     def configure2(self, tile_x, tile_y, model_positions, convergence_step = None):
         for filter in self.filters:
             filter.configure(tile_x, tile_y)
         # int() casting needed for random typing linux bug
-        return int(self.data2.configure(tile_x, tile_y, model_positions, self.slice_index, self.trace_index, self.time_slice, self.stride, convergence_step))
+        return int(self.data2.configure(tile_x, tile_y, model_positions, self.slab_points, self.trace_index, self.slab_range, self.stride, convergence_step))
 
     def get_batches(self, tile_x, tile_y):
         for batch in self.data.get_batch_generator():


### PR DESCRIPTION
In the container.py, trace_handler.py, and correlation_data.py files, the variable name slice shadows the built-in Python function slice. In order to avoid errors and confusion, the following variable name changes were made:

slice --> slab
slices --> slabs
time_slice --> slab_range
slice_index --> slab_points
batch_slice -->batch_slab
self.sample_slice --> self.sample_slab
self.slices --> self.slabs

Additionally, Christopher McLean was added to the list of contributors in README.md.